### PR TITLE
Parse to AST and use printers to go from AST to specific targets

### DIFF
--- a/clj-parse-test.el
+++ b/clj-parse-test.el
@@ -22,177 +22,368 @@
 
 ;;; Code:
 
-(require 'clj-parse)
+(require 'a)
 (require 'ert)
+(require 'clj-parse)
 
-(defmacro clj-parse-eq-test (parse-to-fn test-string expected)
-  `(with-temp-buffer
-     (insert ,test-string)
-     (goto-char 1)
-     (should (equal (,parse-to-fn) ,expected))))
+(defun clj-parse--deftest-mode (mode test-name test-string expected)
+  (let* ((parse-fn (intern (concat "clj-parse-" mode)))
+         (test-name (intern (concat (symbol-name parse-fn) "-" (symbol-name test-name)))))
+    `(ert-deftest ,test-name ()
+       (with-temp-buffer
+         (insert ,test-string)
+         (goto-char 1)
+         (should (equal (,parse-fn) ,expected))))))
 
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; To Elisp code, ala edn.el
-
-(ert-deftest clj-parse-to-elisp-simple-list ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "(1 2 3)"
-    '((1 2 3))))
-
-(ert-deftest clj-parse-to-elisp-empty-list ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "()"
-    '(())))
-
-(ert-deftest clj-parse-to-elisp-list-size-1 ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "(1)"
-    '((1))))
-
-(ert-deftest clj-parse-to-elisp-leafs ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "(nil true false hello-world)"
-    '((nil t nil hello-world))))
-
-(ert-deftest clj-parse-to-elisp-qualified-symbol ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "clojure.string/join"
-    '(clojure.string/join)))
-
-(ert-deftest clj-parse-to-elisp-nested-lists ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "((.9 abc (true) (hello)))"
-    '(((0.9 abc (t) (hello))))))
-
-(ert-deftest clj-parse-to-elisp-strings ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "\"abc hello \\t\\\"x\""
-    '("abc hello \t\"x"))
-  (clj-parse-eq-test clj-parse-to-elisp
-    "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
-    '(("---\f---\"-''-\\-\r\n"))))
-
-(ert-deftest clj-parse-to-elisp-chars ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
-    '((?\n ?\r ?\ ?\t ?a ?b ?c ?x ?y)))
-  (clj-parse-eq-test clj-parse-to-elisp
-    "\"\\u0078 \\o171\""
-    '("x y")))
-
-(ert-deftest clj-parse-to-elisp-keywords ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    ":foo-bar"
-    '(:foo-bar)))
-
-(ert-deftest clj-parse-to-elisp-vector ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "[123]"
-    '([123])))
-
-(ert-deftest clj-parse-to-elisp-map ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "{:count 123}"
-    '(((:count . 123)))))
-
-(ert-deftest clj-parse-to-elisp-set ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "#{:x}"
-    '((:x))))
-
-(ert-deftest clj-parse-to-elisp-discarded ()
-  (clj-parse-eq-test clj-parse-to-elisp
-    "(10 #_11 12 #_#_ 13 14)"
-    '((10 12 14))))
+(defmacro clj-parse-deftest (test-name test-string mode-vs-expected-alist)
+  (declare (indent defun))
+  `(progn
+     ,@(mapcar (lambda (vs) (clj-parse--deftest-mode (car vs)
+                                                     test-name
+                                                     test-string
+                                                     (cadr vs)))
+               mode-vs-expected-alist)))
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; To Clojure/EDN string
+;;; Parser modes
+;; ----------------------------------------------------------------------------
 
-(ert-deftest clj-parse-to-string-simple-list ()
-  (clj-parse-eq-test clj-parse-to-string
-    "(   1 2   3)"
-    "(1 2 3)"))
-
-(ert-deftest clj-parse-to-string-empty-list ()
-  (clj-parse-eq-test clj-parse-to-string
-    "()"
-    "()"))
-
-(ert-deftest clj-parse-to-string-list-size-1 ()
-  (clj-parse-eq-test clj-parse-to-string
-    "(1)"
-    "(1)"))
-
-(ert-deftest clj-parse-to-string-leafs ()
-  (clj-parse-eq-test clj-parse-to-string
-    "(nil true false hello-world)"
-    "(nil true false hello-world)"))
-
-(ert-deftest clj-parse-to-string-qualified-symbol ()
-  (clj-parse-eq-test clj-parse-to-string
-    "clojure.string/join"
-    "clojure.string/join"))
-
-(ert-deftest clj-parse-to-string-nested-lists ()
-  (clj-parse-eq-test clj-parse-to-string
-    "((.9 abc (true) (hello)))"
-    "((.9 abc (true) (hello)))"))
-
-(ert-deftest clj-parse-to-string-strings ()
-  (clj-parse-eq-test clj-parse-to-string
-    "\"abc hello \\t\\\"x\""
-    "\"abc hello \\t\\\"x\"")
-  (clj-parse-eq-test clj-parse-to-string
-    "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
-    "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"))
-
-(ert-deftest clj-parse-to-string-chars ()
-  (clj-parse-eq-test clj-parse-to-string
-    "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
-    "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)")
-  (clj-parse-eq-test clj-parse-to-string
-    "\"\\u0078 \\o171\""
-    "\"\\u0078 \\o171\""))
-
-(ert-deftest clj-parse-to-string-keywords ()
-  (clj-parse-eq-test clj-parse-to-string
-    ":foo-bar"
-    ":foo-bar"))
-
-(ert-deftest clj-parse-to-string-vector ()
-  (clj-parse-eq-test clj-parse-to-string
-    "[123]"
-    "[123]"))
-
-(ert-deftest clj-parse-to-string-map ()
-  (clj-parse-eq-test clj-parse-to-string
-    "{:count 123}"
-    "{:count 123}"))
-
-(ert-deftest clj-parse-to-string-set ()
-  (clj-parse-eq-test clj-parse-to-string
-    "#{:x}"
-    "#{:x}"))
-
-(ert-deftest clj-parse-to-string-discarded ()
-  (clj-parse-eq-test clj-parse-to-string
-    "(10 #_11 12 #_#_ 13 14)"
-    "(10 12 14)"))
+(clj-parse-deftest simple-list "(1 2 3)"
+  (("edn" '((1 2 3)))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :number)
+                                          (:position . 2)
+                                          (:form . "1")
+                                          (:value . 1))
+                                         ((:node-type . :number)
+                                          (:position . 4)
+                                          (:form . "2")
+                                          (:value . 2))
+                                         ((:node-type . :number)
+                                          (:position . 6)
+                                          (:form . "3")
+                                          (:value . 3)))))))))))
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; AST
+(clj-parse-deftest empty-list "()"
+  (("edn" '(()))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . nil))))))))
 
-(ert-deftest clj-parse-ast-simple-list ()
-  (clj-parse-eq-test clj-parse
-    "(1 2 3)"
-    '((type . :root)
-      (subnodes . (((type . :list)
-                    (subnodes . (((type . :number) (form . "1") (pos . 2))
-                                 ((type . :number) (form . "2") (pos . 4))
-                                 ((type . :number) (form . "3") (pos . 6))))))))))
+(clj-parse-deftest size-1 "(1)"
+  (("edn" '((1)))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :number)
+                                          (:position . 2)
+                                          (:form . "1")
+                                          (:value . 1)))))))))))
+
+(clj-parse-deftest leafs "(nil true false hello-world)"
+  (("edn" '((nil t nil hello-world)))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :nil)
+                                          (:position . 2)
+                                          (:form . "nil")
+                                          (:value . nil))
+                                         ((:node-type . :true)
+                                          (:position . 6)
+                                          (:form . "true")
+                                          (:value . t))
+                                         ((:node-type . :false)
+                                          (:position . 11)
+                                          (:form . "false")
+                                          (:value . nil))
+                                         ((:node-type . :symbol)
+                                          (:position . 17)
+                                          (:form . "hello-world")
+                                          (:value . hello-world)))))))))))
+
+(clj-parse-deftest qualified-symbol "clojure.string/join"
+  (("edn" '(clojure.string/join))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :symbol)
+                           (:position . 1)
+                           (:form . "clojure.string/join")
+                           (:value . clojure.string/join))))))))
+
+(clj-parse-deftest nested-lists "((.9 abc (true) (hello)))"
+  (("edn" '(((0.9 abc (t) (hello)))))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :list)
+                                          (:position . 2)
+                                          (:children ((:node-type . :number)
+                                                      (:position . 3)
+                                                      (:form . ".9")
+                                                      (:value . 0.9))
+                                                     ((:node-type . :symbol)
+                                                      (:position . 6)
+                                                      (:form . "abc")
+                                                      (:value . abc))
+                                                     ((:node-type . :list)
+                                                      (:position . 10)
+                                                      (:children ((:node-type . :true)
+                                                                  (:position . 11)
+                                                                  (:form . "true")
+                                                                  (:value . t))))
+                                                     ((:node-type . :list)
+                                                      (:position . 17)
+                                                      (:children ((:node-type . :symbol)
+                                                                  (:position . 18)
+                                                                  (:form . "hello")
+                                                                  (:value . hello)))))))))))))))
+
+(clj-parse-deftest strings-1 "\"abc hello \\t\\\"x\""
+  (("edn" '("abc hello \t\"x"))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :string)
+                           (:position . 1)
+                           (:form . "\"abc hello \\t\\\"x\"")
+                           (:value . "abc hello \t\"x"))))))))
+
+(clj-parse-deftest strings-2 "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
+  (("edn" '(("---\f---\"-''-\\-\r\n")))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :string)
+                                          (:position . 2)
+                                          (:form . "\"---\\f---\\\"-'\\'-\\\\-\\r\\n\"")
+                                          (:value . "---\f---\"-''-\\-\r\n")))))))))))
+
+(clj-parse-deftest chars-1 "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
+  (("edn" '((?\n ?\r ?\ ?\t ?a ?b ?c ?x ?y)))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :character) (:position . 2) (:form . "\\newline") (:value . ?\n))
+                                         ((:node-type . :character) (:position . 11) (:form . "\\return") (:value . ?\r))
+                                         ((:node-type . :character) (:position . 19) (:form . "\\space") (:value . 32))
+                                         ((:node-type . :character) (:position . 26) (:form . "\\tab") (:value . ?\t))
+                                         ((:node-type . :character) (:position . 31) (:form . "\\a") (:value . ?a))
+                                         ((:node-type . :character) (:position . 34) (:form . "\\b") (:value . ?b))
+                                         ((:node-type . :character) (:position . 37) (:form . "\\c") (:value . ?c))
+                                         ((:node-type . :character) (:position . 40) (:form . "\\u0078") (:value . ?x))
+                                         ((:node-type . :character) (:position . 47) (:form . "\\o171") (:value . ?y)))))))))))
+
+(clj-parse-deftest chars-2 "\"\\u0078 \\o171\""
+  (("edn" '("x y"))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :string)
+                           (:position . 1)
+                           (:form . "\"\\u0078 \\o171\"")
+                           (:value . "x y"))))))))
+
+(clj-parse-deftest keywords ":foo-bar"
+  (("edn" '(:foo-bar))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :keyword)
+                           (:position . 1)
+                           (:form . ":foo-bar")
+                           (:value . :foo-bar))))))))
+
+(clj-parse-deftest vector "[123]"
+  (("edn" '([123]))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :vector)
+                           (:position . 1)
+                           (:children . (((:node-type . :number)
+                                          (:position . 2)
+                                          (:form . "123")
+                                          (:value . 123)))))))))))
+
+(clj-parse-deftest map "{:count 123}"
+  (("edn" '(((:count . 123))))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :map)
+                           (:position . 1)
+                           (:children . (((:node-type . :keyword)
+                                          (:position . 2)
+                                          (:form . ":count")
+                                          (:value . :count))
+                                         ((:node-type . :number)
+                                          (:position . 9)
+                                          (:form . "123")
+                                          (:value . 123)))))))))))
+
+(clj-parse-deftest set "#{:x}"
+  (("edn" '((:x)))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :set)
+                           (:position . 1)
+                           (:children . (((:node-type . :keyword)
+                                          (:position . 3)
+                                          (:form . ":x")
+                                          (:value . :x)))))))))))
+
+(clj-parse-deftest discard "(10 #_11 12 #_#_ 13 14)"
+  (("edn" '((10 12)))
+   ("ast" '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :number)
+                                          (:position . 2)
+                                          (:form . "10")
+                                          (:value . 10))
+                                         ((:node-type . :number)
+                                          (:position . 10)
+                                          (:form . "12")
+                                          (:value . 12)))))))))))
+
+
+;;; Printer modes
+;; ----------------------------------------------------------------------------
+
+(ert-deftest clj-parse-ast-print-list ()
+  (should (equal "(0 1 2)"
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :list)
+                                                       (:position . 1)
+                                                       (:children . (((:node-type . :number)
+                                                                      (:position . 2)
+                                                                      (:form . "0")
+                                                                      (:value . 0))
+                                                                     ((:node-type . :number)
+                                                                      (:position . 4)
+                                                                      (:form . "1")
+                                                                      (:value . 1))
+                                                                     ((:node-type . :number)
+                                                                      (:position . 6)
+                                                                      (:form . "2")
+                                                                      (:value . 2))))))))))))
+
+(ert-deftest clj-parse-ast-print-empty-list ()
+  (should (equal "()"
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :list)
+                                                       (:position . 1)
+                                                       (:children . nil)))))))))
+
+(ert-deftest clj-parse-ast-print-nested-list ()
+  (should (equal "((.9 abc (true) (hello)))"
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :list)
+                                                       (:position . 1)
+                                                       (:children . (((:node-type . :list)
+                                                                      (:position . 2)
+                                                                      (:children ((:node-type . :number)
+                                                                                  (:position . 3)
+                                                                                  (:form . ".9")
+                                                                                  (:value . 0.9))
+                                                                                 ((:node-type . :symbol)
+                                                                                  (:position . 6)
+                                                                                  (:form . "abc")
+                                                                                  (:value . abc))
+                                                                                 ((:node-type . :list)
+                                                                                  (:position . 10)
+                                                                                  (:children ((:node-type . :true)
+                                                                                              (:position . 11)
+                                                                                              (:form . "true")
+                                                                                              (:value . t))))
+                                                                                 ((:node-type . :list)
+                                                                                  (:position . 17)
+                                                                                  (:children ((:node-type . :symbol)
+                                                                                              (:position . 18)
+                                                                                              (:form . "hello")
+                                                                                              (:value . hello))))))))))))))))
+
+(ert-deftest clj-parse-ast-print-string ()
+  (should (equal "\"abc hello \\t\\\"x\""
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :string)
+                                                       (:position . 1)
+                                                       (:form . "\"abc hello \\t\\\"x\"")
+                                                       (:value . "abc hello \t\"x")))))))))
+
+(ert-deftest clj-parse-ast-print-chars ()
+  (should (equal "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
+                 (clj-parse-ast-print '((:node-type . :root)
+            (:position . 0)
+            (:children . (((:node-type . :list)
+                           (:position . 1)
+                           (:children . (((:node-type . :character) (:position . 2) (:form . "\\newline") (:value . ?\n))
+                                         ((:node-type . :character) (:position . 11) (:form . "\\return") (:value . ?\r))
+                                         ((:node-type . :character) (:position . 19) (:form . "\\space") (:value . 32))
+                                         ((:node-type . :character) (:position . 26) (:form . "\\tab") (:value . ?\t))
+                                         ((:node-type . :character) (:position . 31) (:form . "\\a") (:value . ?a))
+                                         ((:node-type . :character) (:position . 34) (:form . "\\b") (:value . ?b))
+                                         ((:node-type . :character) (:position . 37) (:form . "\\c") (:value . ?c))
+                                         ((:node-type . :character) (:position . 40) (:form . "\\u0078") (:value . ?x))
+                                         ((:node-type . :character) (:position . 47) (:form . "\\o171") (:value . ?y))))))))))))
+
+(ert-deftest clj-parse-ast-print-keyword ()
+  (should (equal ":foo-bar"
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :keyword)
+                                                       (:position . 1)
+                                                       (:form . ":foo-bar")
+                                                       (:value . :foo-bar)))))))))
+
+(ert-deftest clj-parse-ast-print-vector ()
+  (should (equal "[123]"
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :vector)
+                                                       (:position . 1)
+                                                       (:children . (((:node-type . :number)
+                                                                      (:position . 2)
+                                                                      (:form . "123")
+                                                                      (:value . 123))))))))))))
+
+(ert-deftest clj-parse-ast-print-map ()
+  (should (equal "{:count 123}"
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :map)
+                                                       (:position . 1)
+                                                       (:children . (((:node-type . :keyword)
+                                                                      (:position . 2)
+                                                                      (:form . ":count")
+                                                                      (:value . :count))
+                                                                     ((:node-type . :number)
+                                                                      (:position . 9)
+                                                                      (:form . "123")
+                                                                      (:value . 123))))))))))))
+
+(ert-deftest clj-parse-ast-print-set ()
+  (should (equal "#{:x}"
+                 (clj-parse-ast-print '((:node-type . :root)
+                                        (:position . 0)
+                                        (:children . (((:node-type . :set)
+                                                       (:position . 1)
+                                                       (:children . (((:node-type . :keyword)
+                                                                      (:position . 3)
+                                                                      (:form . ":x")
+                                                                      (:value . :x))))))))))))
 
 (provide 'clj-parse-test)
 

--- a/clj-parse-test.el
+++ b/clj-parse-test.el
@@ -25,184 +25,174 @@
 (require 'clj-parse)
 (require 'ert)
 
-(defmacro clj-parse-deftest (name parse-to-fn test-string expected)
-  (declare (indent defun))
-  `(ert-deftest ,name ()
-     (with-temp-buffer
-       (insert ,test-string)
-       (goto-char 1)
-       (should (equal (,parse-to-fn) ,expected)))))
+(defmacro clj-parse-eq-test (parse-to-fn test-string expected)
+  `(with-temp-buffer
+     (insert ,test-string)
+     (goto-char 1)
+     (should (equal (,parse-to-fn) ,expected))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; To Elisp code, ala edn.el
 
-(clj-parse-deftest clj-parse-to-elisp-simple-list
-  clj-parse-to-elisp
-  "(1 2 3)"
-  '((1 2 3)))
+(ert-deftest clj-parse-to-elisp-simple-list ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "(1 2 3)"
+    '((1 2 3))))
 
-(clj-parse-deftest clj-parse-to-elisp-empty-list
-  clj-parse-to-elisp
-  "()"
-  '(()))
+(ert-deftest clj-parse-to-elisp-empty-list ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "()"
+    '(())))
 
-(clj-parse-deftest clj-parse-to-elisp-list-size-1
-  clj-parse-to-elisp
-  "(1)"
-  '((1)))
+(ert-deftest clj-parse-to-elisp-list-size-1 ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "(1)"
+    '((1))))
 
-(clj-parse-deftest clj-parse-to-elisp-leafs
-  clj-parse-to-elisp
-  "(nil true false hello-world)"
-  '((nil t nil hello-world)))
+(ert-deftest clj-parse-to-elisp-leafs ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "(nil true false hello-world)"
+    '((nil t nil hello-world))))
 
-(clj-parse-deftest clj-parse-to-elisp-qualified-symbol
-  clj-parse-to-elisp
-  "clojure.string/join"
-  '(clojure.string/join))
+(ert-deftest clj-parse-to-elisp-qualified-symbol ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "clojure.string/join"
+    '(clojure.string/join)))
 
-(clj-parse-deftest clj-parse-to-elisp-nested-lists
-  clj-parse-to-elisp
-  "((.9 abc (true) (hello)))"
-  '(((0.9 abc (t) (hello)))))
+(ert-deftest clj-parse-to-elisp-nested-lists ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "((.9 abc (true) (hello)))"
+    '(((0.9 abc (t) (hello))))))
 
-(clj-parse-deftest clj-parse-to-elisp-strings-1
-  clj-parse-to-elisp
-  "\"abc hello \\t\\\"x\""
-  '("abc hello \t\"x"))
+(ert-deftest clj-parse-to-elisp-strings ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "\"abc hello \\t\\\"x\""
+    '("abc hello \t\"x"))
+  (clj-parse-eq-test clj-parse-to-elisp
+    "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
+    '(("---\f---\"-''-\\-\r\n"))))
 
-(clj-parse-deftest clj-parse-to-elisp-strings-2
-  clj-parse-to-elisp
-  "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
-  '(("---\f---\"-''-\\-\r\n")))
+(ert-deftest clj-parse-to-elisp-chars ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
+    '((?\n ?\r ?\ ?\t ?a ?b ?c ?x ?y)))
+  (clj-parse-eq-test clj-parse-to-elisp
+    "\"\\u0078 \\o171\""
+    '("x y")))
 
-(clj-parse-deftest clj-parse-to-elisp-chars-1
-  clj-parse-to-elisp
-  "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
-  '((?\n ?\r ?\ ?\t ?a ?b ?c ?x ?y)))
+(ert-deftest clj-parse-to-elisp-keywords ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    ":foo-bar"
+    '(:foo-bar)))
 
-(clj-parse-deftest clj-parse-to-elisp-chars-2
-  clj-parse-to-elisp
-  "\"\\u0078 \\o171\""
-  '("x y"))
+(ert-deftest clj-parse-to-elisp-vector ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "[123]"
+    '([123])))
 
-(clj-parse-deftest clj-parse-to-elisp-keywords
-  clj-parse-to-elisp
-  ":foo-bar"
-  '(:foo-bar))
+(ert-deftest clj-parse-to-elisp-map ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "{:count 123}"
+    '(((:count . 123)))))
 
-(clj-parse-deftest clj-parse-to-elisp-vector
-  clj-parse-to-elisp
-  "[123]"
-  '([123]))
+(ert-deftest clj-parse-to-elisp-set ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "#{:x}"
+    '((:x))))
 
-(clj-parse-deftest clj-parse-to-elisp-map
-  clj-parse-to-elisp
-  "{:count 123}"
-  '(((:count . 123))))
-
-(clj-parse-deftest clj-parse-to-elisp-set
-  clj-parse-to-elisp
-  "#{:x}"
-  '((:x)))
-
-(clj-parse-deftest clj-parse-to-elisp-discarded
-  clj-parse-to-elisp
-  "(10 #_11 12 #_#_ 13 14)"
-  '((10 12 14)))
+(ert-deftest clj-parse-to-elisp-discarded ()
+  (clj-parse-eq-test clj-parse-to-elisp
+    "(10 #_11 12 #_#_ 13 14)"
+    '((10 12 14))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; To Clojure/EDN string
 
-(clj-parse-deftest clj-parse-to-string-simple-list
-  clj-parse-to-string
-  "(   1 2   3)"
-  "(1 2 3)")
+(ert-deftest clj-parse-to-string-simple-list ()
+  (clj-parse-eq-test clj-parse-to-string
+    "(   1 2   3)"
+    "(1 2 3)"))
 
-(clj-parse-deftest clj-parse-to-string-empty-list
-  clj-parse-to-string
-  "()"
-  "()")
+(ert-deftest clj-parse-to-string-empty-list ()
+  (clj-parse-eq-test clj-parse-to-string
+    "()"
+    "()"))
 
-(clj-parse-deftest clj-parse-to-string-list-size-1
-  clj-parse-to-string
-  "(1)"
-  "(1)")
+(ert-deftest clj-parse-to-string-list-size-1 ()
+  (clj-parse-eq-test clj-parse-to-string
+    "(1)"
+    "(1)"))
 
-(clj-parse-deftest clj-parse-to-string-leafs
-  clj-parse-to-string
-  "(nil true false hello-world)"
-  "(nil true false hello-world)")
+(ert-deftest clj-parse-to-string-leafs ()
+  (clj-parse-eq-test clj-parse-to-string
+    "(nil true false hello-world)"
+    "(nil true false hello-world)"))
 
-(clj-parse-deftest clj-parse-to-string-qualified-symbol
-  clj-parse-to-string
-  "clojure.string/join"
-  "clojure.string/join")
+(ert-deftest clj-parse-to-string-qualified-symbol ()
+  (clj-parse-eq-test clj-parse-to-string
+    "clojure.string/join"
+    "clojure.string/join"))
 
-(clj-parse-deftest clj-parse-to-string-nested-lists
-  clj-parse-to-string
-  "((.9 abc (true) (hello)))"
-  "((.9 abc (true) (hello)))")
+(ert-deftest clj-parse-to-string-nested-lists ()
+  (clj-parse-eq-test clj-parse-to-string
+    "((.9 abc (true) (hello)))"
+    "((.9 abc (true) (hello)))"))
 
-(clj-parse-deftest clj-parse-to-string-strings-1
-  clj-parse-to-string
-  "\"abc hello \\t\\\"x\""
-  "\"abc hello \\t\\\"x\"")
+(ert-deftest clj-parse-to-string-strings ()
+  (clj-parse-eq-test clj-parse-to-string
+    "\"abc hello \\t\\\"x\""
+    "\"abc hello \\t\\\"x\"")
+  (clj-parse-eq-test clj-parse-to-string
+    "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
+    "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"))
 
-(clj-parse-deftest clj-parse-to-string-strings-2
-  clj-parse-to-string
-  "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
-  "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")")
+(ert-deftest clj-parse-to-string-chars ()
+  (clj-parse-eq-test clj-parse-to-string
+    "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
+    "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)")
+  (clj-parse-eq-test clj-parse-to-string
+    "\"\\u0078 \\o171\""
+    "\"\\u0078 \\o171\""))
 
-(clj-parse-deftest clj-parse-to-string-chars-1
-  clj-parse-to-string
-  "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
-  "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)")
+(ert-deftest clj-parse-to-string-keywords ()
+  (clj-parse-eq-test clj-parse-to-string
+    ":foo-bar"
+    ":foo-bar"))
 
-(clj-parse-deftest clj-parse-to-string-chars-2
-  clj-parse-to-string
-  "\"\\u0078 \\o171\""
-  "\"\\u0078 \\o171\"")
+(ert-deftest clj-parse-to-string-vector ()
+  (clj-parse-eq-test clj-parse-to-string
+    "[123]"
+    "[123]"))
 
-(clj-parse-deftest clj-parse-to-string-keywords
-  clj-parse-to-string
-  ":foo-bar"
-  ":foo-bar")
+(ert-deftest clj-parse-to-string-map ()
+  (clj-parse-eq-test clj-parse-to-string
+    "{:count 123}"
+    "{:count 123}"))
 
-(clj-parse-deftest clj-parse-to-string-vector
-  clj-parse-to-string
-  "[123]"
-  "[123]")
+(ert-deftest clj-parse-to-string-set ()
+  (clj-parse-eq-test clj-parse-to-string
+    "#{:x}"
+    "#{:x}"))
 
-(clj-parse-deftest clj-parse-to-string-map
-  clj-parse-to-string
-  "{:count 123}"
-  "{:count 123}")
-
-(clj-parse-deftest clj-parse-to-string-set
-  clj-parse-to-string
-  "#{:x}"
-  "#{:x}")
-
-(clj-parse-deftest clj-parse-to-string-discarded
-  clj-parse-to-string
-  "(10 #_11 12 #_#_ 13 14)"
-  "(10 12 14)")
+(ert-deftest clj-parse-to-string-discarded ()
+  (clj-parse-eq-test clj-parse-to-string
+    "(10 #_11 12 #_#_ 13 14)"
+    "(10 12 14)"))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; AST
 
-(clj-parse-deftest clj-parse-ast-simple-list
-  clj-parse
-  "(1 2 3)"
-  '((type . :root)
-    (subnodes . (((type . :list)
-                  (subnodes . (((type . :number) (form . "1") (pos . 2))
-                               ((type . :number) (form . "2") (pos . 4))
-                               ((type . :number) (form . "3") (pos . 6)))))))))
+(ert-deftest clj-parse-ast-simple-list ()
+  (clj-parse-eq-test clj-parse
+    "(1 2 3)"
+    '((type . :root)
+      (subnodes . (((type . :list)
+                    (subnodes . (((type . :number) (form . "1") (pos . 2))
+                                 ((type . :number) (form . "2") (pos . 4))
+                                 ((type . :number) (form . "3") (pos . 6))))))))))
 
 (provide 'clj-parse-test)
 

--- a/clj-parse-test.el
+++ b/clj-parse-test.el
@@ -25,81 +25,184 @@
 (require 'clj-parse)
 (require 'ert)
 
-(ert-deftest clj-parse-test ()
-  (with-temp-buffer
-    (insert "(1 2 3)")
-    (goto-char 1)
-    (should (equal (clj-parse) '((1 2 3)))))
+(defmacro clj-parse-deftest (name parse-to-fn test-string expected)
+  (declare (indent defun))
+  `(ert-deftest ,name ()
+     (with-temp-buffer
+       (insert ,test-string)
+       (goto-char 1)
+       (should (equal (,parse-to-fn) ,expected)))))
 
-  (with-temp-buffer
-    (insert "()")
-    (goto-char 1)
-    (should (equal (clj-parse) '(()))))
 
-  (with-temp-buffer
-    (insert "(1)")
-    (goto-char 1)
-    (should (equal (clj-parse) '((1)))))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; To Elisp code, ala edn.el
 
-  (with-temp-buffer
-    (insert "(nil true false hello-world)")
-    (goto-char 1)
-    (should (equal (clj-parse) '((nil t nil hello-world)))))
+(clj-parse-deftest clj-parse-to-elisp-simple-list
+  clj-parse-to-elisp
+  "(1 2 3)"
+  '((1 2 3)))
 
-  (with-temp-buffer
-    (insert "clojure.string/join")
-    (goto-char 1)
-    (should (equal (clj-parse) '(clojure.string/join))))
+(clj-parse-deftest clj-parse-to-elisp-empty-list
+  clj-parse-to-elisp
+  "()"
+  '(()))
 
-  (with-temp-buffer
-    (insert "((.9 abc (true) (hello)))")
-    (goto-char 1)
-    (should (equal (clj-parse) '(((0.9 abc (t) (hello)))))))
+(clj-parse-deftest clj-parse-to-elisp-list-size-1
+  clj-parse-to-elisp
+  "(1)"
+  '((1)))
 
-  (with-temp-buffer
-    (insert "\"abc hello \\t\\\"x\"")
-    (goto-char 1)
-    (should (equal (clj-parse) '("abc hello \t\"x"))))
+(clj-parse-deftest clj-parse-to-elisp-leafs
+  clj-parse-to-elisp
+  "(nil true false hello-world)"
+  '((nil t nil hello-world)))
 
-  (with-temp-buffer
-    (insert "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")")
-    (goto-char 1)
-    (should (equal (clj-parse) '(("---\f---\"-''-\\-\r\n")))))
+(clj-parse-deftest clj-parse-to-elisp-qualified-symbol
+  clj-parse-to-elisp
+  "clojure.string/join"
+  '(clojure.string/join))
 
-  (with-temp-buffer
-    (insert "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)")
-    (goto-char 1)
-    (should (equal (clj-parse) '((?\n ?\r ?\ ?\t ?a ?b ?c ?x ?y)))))
+(clj-parse-deftest clj-parse-to-elisp-nested-lists
+  clj-parse-to-elisp
+  "((.9 abc (true) (hello)))"
+  '(((0.9 abc (t) (hello)))))
 
-  (with-temp-buffer
-    (insert "\"\\u0078 \\o171\"")
-    (goto-char 1)
-    (should (equal (clj-parse) '("x y"))))
+(clj-parse-deftest clj-parse-to-elisp-strings-1
+  clj-parse-to-elisp
+  "\"abc hello \\t\\\"x\""
+  '("abc hello \t\"x"))
 
-  (with-temp-buffer
-    (insert ":foo-bar")
-    (goto-char 1)
-    (should (equal (clj-parse) '(:foo-bar))))
+(clj-parse-deftest clj-parse-to-elisp-strings-2
+  clj-parse-to-elisp
+  "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
+  '(("---\f---\"-''-\\-\r\n")))
 
-  (with-temp-buffer
-    (insert "[123]")
-    (goto-char 1)
-    (should (equal (clj-parse) '([123]))))
+(clj-parse-deftest clj-parse-to-elisp-chars-1
+  clj-parse-to-elisp
+  "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
+  '((?\n ?\r ?\ ?\t ?a ?b ?c ?x ?y)))
 
-  (with-temp-buffer
-    (insert "{:count 123}")
-    (goto-char 1)
-    (should (equal (clj-parse) '(((:count . 123))))))
+(clj-parse-deftest clj-parse-to-elisp-chars-2
+  clj-parse-to-elisp
+  "\"\\u0078 \\o171\""
+  '("x y"))
 
-  (with-temp-buffer
-    (insert "#{:x}")
-    (goto-char 1)
-    (should (equal (clj-parse) '((:x)))))
+(clj-parse-deftest clj-parse-to-elisp-keywords
+  clj-parse-to-elisp
+  ":foo-bar"
+  '(:foo-bar))
 
-  (with-temp-buffer
-    (insert "(10 #_11 12 #_#_ 13 14)")
-    (goto-char 1)
-    (should (equal (clj-parse) '((10 12))))))
+(clj-parse-deftest clj-parse-to-elisp-vector
+  clj-parse-to-elisp
+  "[123]"
+  '([123]))
+
+(clj-parse-deftest clj-parse-to-elisp-map
+  clj-parse-to-elisp
+  "{:count 123}"
+  '(((:count . 123))))
+
+(clj-parse-deftest clj-parse-to-elisp-set
+  clj-parse-to-elisp
+  "#{:x}"
+  '((:x)))
+
+(clj-parse-deftest clj-parse-to-elisp-discarded
+  clj-parse-to-elisp
+  "(10 #_11 12 #_#_ 13 14)"
+  '((10 12 14)))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; To Clojure/EDN string
+
+(clj-parse-deftest clj-parse-to-string-simple-list
+  clj-parse-to-string
+  "(   1 2   3)"
+  "(1 2 3)")
+
+(clj-parse-deftest clj-parse-to-string-empty-list
+  clj-parse-to-string
+  "()"
+  "()")
+
+(clj-parse-deftest clj-parse-to-string-list-size-1
+  clj-parse-to-string
+  "(1)"
+  "(1)")
+
+(clj-parse-deftest clj-parse-to-string-leafs
+  clj-parse-to-string
+  "(nil true false hello-world)"
+  "(nil true false hello-world)")
+
+(clj-parse-deftest clj-parse-to-string-qualified-symbol
+  clj-parse-to-string
+  "clojure.string/join"
+  "clojure.string/join")
+
+(clj-parse-deftest clj-parse-to-string-nested-lists
+  clj-parse-to-string
+  "((.9 abc (true) (hello)))"
+  "((.9 abc (true) (hello)))")
+
+(clj-parse-deftest clj-parse-to-string-strings-1
+  clj-parse-to-string
+  "\"abc hello \\t\\\"x\""
+  "\"abc hello \\t\\\"x\"")
+
+(clj-parse-deftest clj-parse-to-string-strings-2
+  clj-parse-to-string
+  "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")"
+  "(\"---\\f---\\\"-'\\'-\\\\-\\r\\n\")")
+
+(clj-parse-deftest clj-parse-to-string-chars-1
+  clj-parse-to-string
+  "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)"
+  "(\\newline \\return \\space \\tab \\a \\b \\c \\u0078 \\o171)")
+
+(clj-parse-deftest clj-parse-to-string-chars-2
+  clj-parse-to-string
+  "\"\\u0078 \\o171\""
+  "\"\\u0078 \\o171\"")
+
+(clj-parse-deftest clj-parse-to-string-keywords
+  clj-parse-to-string
+  ":foo-bar"
+  ":foo-bar")
+
+(clj-parse-deftest clj-parse-to-string-vector
+  clj-parse-to-string
+  "[123]"
+  "[123]")
+
+(clj-parse-deftest clj-parse-to-string-map
+  clj-parse-to-string
+  "{:count 123}"
+  "{:count 123}")
+
+(clj-parse-deftest clj-parse-to-string-set
+  clj-parse-to-string
+  "#{:x}"
+  "#{:x}")
+
+(clj-parse-deftest clj-parse-to-string-discarded
+  clj-parse-to-string
+  "(10 #_11 12 #_#_ 13 14)"
+  "(10 12 14)")
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; AST
+
+(clj-parse-deftest clj-parse-ast-simple-list
+  clj-parse
+  "(1 2 3)"
+  '((type . :root)
+    (subnodes . (((type . :list)
+                  (subnodes . (((type . :number) (form . "1") (pos . 2))
+                               ((type . :number) (form . "2") (pos . 4))
+                               ((type . :number) (form . "3") (pos . 6)))))))))
 
 (provide 'clj-parse-test)
 

--- a/clj-parse.el
+++ b/clj-parse.el
@@ -99,14 +99,10 @@
      ((eq first-char ?o) (string-to-number (substring c 2) 8))
      (t first-char))))
 
-(defun clj-parse--next ()
-  (setq next (clj-lex-next))
-  (while (eq (clj-lex-token-type next) :whitespace)
-    (setq next (clj-parse--next)))
-  next)
-
 (defun clj-parse--ast-reduce1 (stack leaf)
-  (push leaf stack))
+  (if (eq (clj-lex-token-type leaf) :whitespace)
+      stack
+    (push leaf stack)))
 
 (defun clj-parse--ast-reduceN (stack node subnodes)
   (push
@@ -142,7 +138,7 @@
 (defun clj-parse-reduce (reduce1 reduceN)
   (let ((stack nil))
 
-    (while (not (eq (clj-lex-token-type (setq token (clj-parse--next))) :eof))
+    (while (not (eq (clj-lex-token-type (setq token (clj-lex-next))) :eof))
       (message "STACK: %S" stack)
       (message "TOKEN: %S\n" token)
 


### PR DESCRIPTION
This refactor includes the following:

- Make parser produce an AST by default.
- Switch to lexical binding and fix some broken var references.
- Reorganize reduce functions a bit.
- Rename some private functions to follow the `--` convention.
- Separate all test cases.

It also includes two printers for the AST, one that goes to elisp code (ala edn.el) and one that returns EDN/Clojure strings.